### PR TITLE
Add workflow to run data validation tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -1,0 +1,43 @@
+name: Data Tests
+
+on: [push, pull_request]
+
+jobs:
+  data_tests:
+    name: Data tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [duplicate_entries, file_format, missing_values, vote_breakdown_totals]
+
+    env:
+      LOG_FILE: ${{ github.workspace }}/${{ matrix.test }}.txt
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Check out data
+      uses: actions/checkout@v2.3.4
+      with:
+        path: data
+
+    - name: Check out data tests
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: openelections/openelections-data-tests
+        ref: v2.0.0
+        path: data_tests
+
+    - name: Run data tests
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py --group-failures --log-file=${{ env.LOG_FILE }} ${{ matrix.test }} ${{ github.workspace }}/data
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2.2.4
+      if: failure()
+      with:
+        name: ${{ matrix.test }}_full_logs
+        path: ${{ env.LOG_FILE }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Build Status](https://github.com/openelections/openelections-data-md/actions/workflows/data_tests.yml/badge.svg?branch=main)](https://github.com/openelections/openelections-data-md/actions/workflows/data_tests.yml?query=branch%3Amain)
+
 # openelections-data-md
 Custom election results data for Maryland elections


### PR DESCRIPTION
This adds a workflow to run the [data validation](https://github.com/openelections/openelections-data-tests) tests.
