### PR TITLE
Update tj-actions/changed-files to address security vulnerability

### DIFF
--- a/.github/workflows/data_tests_changed_files.yml
+++ b/.github/workflows/data_tests_changed_files.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Get changed *.csv files
       id: changed-files
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@v46
       with:
         path: data
         files: |


### PR DESCRIPTION
This updates the version of the `tj-actions/changed-files` GitHub Action. A [security vulnerability](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) that allowed remote attackers to discover secrets existed between March 14 and March 15, 2025.

We did not appear to have any dependent builds run during that timeframe.